### PR TITLE
Add color-coded links for extra nav

### DIFF
--- a/estilo_landing_page.css
+++ b/estilo_landing_page.css
@@ -78,6 +78,46 @@
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.75%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
 }
 
+.navbar-lower {
+    background-color: var(--tertiary-color);
+}
+
+.navbar-lower .nav-link {
+    color: var(--secondary-color) !important;
+    font-size: 0.84rem;
+    padding: 0.5rem 1rem !important;
+    transition: all 0.3s ease;
+}
+
+.navbar-lower .nav-link:hover {
+    color: var(--important-color) !important;
+}
+
+/* Individual colors for each lower navbar link */
+.nav-link.ec-link {
+    color: #4DA8DA !important;
+}
+
+.nav-link.ec-link:hover {
+    color: #4DA8DA !important;
+}
+
+.nav-link.suayed-link {
+    color: #48b76d !important;
+}
+
+.nav-link.suayed-link:hover {
+    color: #48b76d !important;
+}
+
+.nav-link.lenguas-link {
+    color: #19BB98 !important;
+}
+
+.nav-link.lenguas-link:hover {
+    color: #19BB98 !important;
+}
+
 .footer-carbon {
     background-color: #333333;
     /* Color carbón */

--- a/navbar.html
+++ b/navbar.html
@@ -50,6 +50,30 @@
                     </a>
                 </li>
             </ul>
+            <!-- Opciones extra para dispositivos móviles -->
+            <hr class="text-white d-lg-none">
+            <ul class="navbar-nav gap-lg-3 d-lg-none">
+                <li class="nav-item">
+                    <a class="nav-link ec-link px-3 py-2 rounded" href="#">
+                        Educación continua
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link suayed-link px-3 py-2 rounded" href="#">
+                        SUAYED
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link lenguas-link px-3 py-2 rounded" href="#">
+                        Centro de Lenguas Extranjeras
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="navbar-lower d-none d-lg-flex justify-content-center gap-4 mt-2 w-100">
+            <a class="nav-link ec-link px-3 py-2 rounded" href="#">Educación continua</a>
+            <a class="nav-link suayed-link px-3 py-2 rounded" href="#">SUAYED</a>
+            <a class="nav-link lenguas-link px-3 py-2 rounded" href="#">Centro de Lenguas Extranjeras</a>
         </div>
     </div>
 </nav>


### PR DESCRIPTION
## Summary
- colorize each lower navigation link
- apply these classes in mobile and desktop menus

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68632bec29f08322a01a09d94790434d