### PR TITLE
Add error pages for 404 and 500

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+app.log

--- a/404.html
+++ b/404.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Página no encontrada</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="estilo_landing_page.css">
+</head>
+<body>
+    <header id="navbar-placeholder"></header>
+    <main class="container text-center py-5">
+        <h1 class="display-4">404</h1>
+        <p class="lead">La página que buscas no existe.</p>
+        <a href="index.html" class="btn btn-primary">Volver al inicio</a>
+    </main>
+    <div id="footer-placeholder"></div>
+    <script src="load-components.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/500.html
+++ b/500.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Error interno</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="estilo_landing_page.css">
+</head>
+<body>
+    <header id="navbar-placeholder"></header>
+    <main class="container text-center py-5">
+        <h1 class="display-4">500</h1>
+        <p class="lead">Ha ocurrido un error inesperado.</p>
+        <a href="index.html" class="btn btn-primary">Volver al inicio</a>
+    </main>
+    <div id="footer-placeholder"></div>
+    <script src="load-components.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/app.py
+++ b/app.py
@@ -1,0 +1,82 @@
+import json
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from flask import Flask, Blueprint, jsonify, render_template
+
+
+def create_app(config=None):
+    """Create and configure the Flask application."""
+    app = Flask(__name__, template_folder='.', static_folder='resources')
+
+    if config:
+        app.config.update(config)
+
+    # Configure logging
+    log_handler = RotatingFileHandler('app.log', maxBytes=100000, backupCount=3)
+    log_handler.setLevel(logging.INFO)
+    formatter = logging.Formatter('[%(asctime)s] %(levelname)s in %(module)s: %(message)s')
+    log_handler.setFormatter(formatter)
+    app.logger.addHandler(log_handler)
+
+    # Blueprint for main pages
+    main_bp = Blueprint('main', __name__)
+
+    @main_bp.route('/')
+    def home():
+        return render_template('index.html')
+
+    @main_bp.route('/acerca')
+    def about():
+        return render_template('acerca-de.html')
+
+    @main_bp.route('/contacto')
+    def contact():
+        return render_template('contacto.html')
+
+    @main_bp.route('/oferta')
+    def offer():
+        return render_template('oferta-educativa.html')
+
+    @main_bp.route('/estadisticas')
+    def statistics():
+        return render_template('estadisticas.html')
+
+    @main_bp.route('/preguntas')
+    def faq():
+        return render_template('preguntas-frecuentes.html')
+
+    app.register_blueprint(main_bp)
+
+    # Blueprint for API routes
+    api_bp = Blueprint('api', __name__, url_prefix='/api')
+    data_file = Path('data/courses.json')
+
+    @api_bp.route('/courses')
+    def list_courses():
+        if data_file.exists():
+            with data_file.open('r', encoding='utf-8') as f:
+                courses = json.load(f)
+        else:
+            courses = []
+        return jsonify(courses)
+
+    app.register_blueprint(api_bp)
+
+    # Error handlers
+    @app.errorhandler(404)
+    def not_found(error):  # pylint: disable=unused-argument
+        return render_template('404.html'), 404
+
+    @app.errorhandler(500)
+    def server_error(error):  # pylint: disable=unused-argument
+        app.logger.exception('Server error: %s', error)
+        return render_template('500.html'), 500
+
+    return app
+
+
+if __name__ == '__main__':
+    application = create_app({'JSON_AS_ASCII': False})
+    application.run(debug=True)

--- a/data/courses.json
+++ b/data/courses.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": 1,
+        "nombre": "Diplomado en tecnología",
+        "descripcion": "Programa introductorio a las tecnologías de la información."
+    },
+    {
+        "id": 2,
+        "nombre": "Curso de verano de desarrollo web",
+        "descripcion": "Aprende a crear sitios web con HTML, CSS y JavaScript."
+    }
+]


### PR DESCRIPTION
## Summary
- add simple HTML templates `404.html` and `500.html`
- render these templates from Flask error handlers

## Testing
- `python -m py_compile app.py`
- `python app.py & sleep 2; pkill -f app.py`


------
https://chatgpt.com/codex/tasks/task_e_68658472d7a88322a28120d792dc183a